### PR TITLE
Fix 1 typo and change wording a bit

### DIFF
--- a/org-agenda-conflict.el
+++ b/org-agenda-conflict.el
@@ -57,7 +57,8 @@
         (cons start end)))))
 
 (defun org-agenda-conflict--check (item-1 item-2)
-  "Check if two agenda items conflict based on their respective schedule."
+  "Check if two agenda items ITEM-1 and ITEM-2 conflict.
+Conflicts are determined based on their respective schedule."
 
   (when (and item-1 item-2)
     (let ((beg-1 (car item-1))

--- a/org-agenda-conflict.el
+++ b/org-agenda-conflict.el
@@ -25,11 +25,8 @@
 
 ;;; Commentary:
 
-;; This code mark conflicting items in the org agenda. Conflicting
+;; This code marks conflicting items in the org agenda. Conflicting
 ;; items are items with an overlap between their start and end date.
-;; The marking assumes that items are sorted and only checks for
-;; conflicts between adjacent lines. It can proably be extended
-;; to check for conflicts between all items but this would slow things.
 ;;
 ;;; Usage:
 

--- a/org-agenda-conflict.el
+++ b/org-agenda-conflict.el
@@ -37,10 +37,13 @@
 (require 'org-agenda)
 
 (defun org-agenda-conflict--get-item ()
-  "Get date range for an agenda item unless tagged CANCELLED."
+  "Return the date range of an agenda item at point unless tagged CANCELLED.
+
+The data range is a cons of the start and end date timestamp."
 
   (when-let* ((date (get-text-property (point) 'date))
               (tags (or (get-text-property (point) 'tags) '()))
+              ;; For e.g. 11:30, time-of-day is "1130"
               (time-of-day (get-text-property (point) 'time-of-day))
               (duration (get-text-property (point) 'duration)))
     (when (not (member "CANCELLED" tags))
@@ -54,8 +57,7 @@
         (cons start end)))))
 
 (defun org-agenda-conflict--check (item-1 item-2)
-  "Check if two agenda items ITEM-1 and ITEM-2 conflict.
-Conflicts are determined based on their respective schedule."
+  "Check if date ranges ITEM-1 and ITEM-2 overlap."
 
   (when (and item-1 item-2)
     (let ((beg-1 (car item-1))

--- a/org-agenda-conflict.el
+++ b/org-agenda-conflict.el
@@ -27,6 +27,9 @@
 
 ;; This code mark conflicting items in the org agenda. Conflicting
 ;; items are items with an overlap between their start and end date.
+;; The marking assumes that items are sorted and only checks for
+;; conflicts between adjacent lines. It can proably be extended
+;; to check for conflicts between all items but this would slow things.
 ;;
 ;;; Usage:
 
@@ -38,7 +41,7 @@
 
 (defun org-agenda-conflict--get-item ()
   "Get date range for an agenda item unless tagged CANCELLED."
-  
+
   (when-let* ((date (get-text-property (point) 'date))
               (tags (or (get-text-property (point) 'tags) '()))
               (time-of-day (get-text-property (point) 'time-of-day))
@@ -69,9 +72,9 @@
 
 
 (defun org-agenda-conflict-mark (face)
-  "Mark items whose schedule conflct with face FACE.
+  "Mark items whose schedule conflict with face FACE.
 Tags are not marked."
-  
+
   (goto-char (point-min))
   (while (not (eobp))
     (let ((inhibit-read-only t)


### PR DESCRIPTION
Found 1 typo at the bottom, and then checked the rest of the document. You can freely discard lines 30/31.